### PR TITLE
Add more common `curl` options

### DIFF
--- a/app/Console/Commands/CurlCommand.php
+++ b/app/Console/Commands/CurlCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 
 class CurlCommand extends Command
 {
-    protected $signature = 'curl {--X|request=GET} {--H|header=*} {--d|data=*} {--F|form=*} {url}';
+    protected $signature = 'curl {--X|request=GET} {--H|header=*} {--d|data=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--retry=} {--s|silent} {--u|user=} {url}';
 
     protected $description = 'Parse UNIX curl command';
 
@@ -18,6 +18,11 @@ class CurlCommand extends Command
             'headers' => $this->option('header'),
             'data' => $this->option('data'),
             'fields' => $this->option('form'),
+            'digest' => $this->option('digest'),
+            'basic' => $this->option('basic'),
+            'timeout' => $this->option('connect-timeout'),
+            'retry' => $this->option('retry'),
+            'silent' => $this->option('silent'),
             // TODO: map more options...
         ];
 

--- a/app/Console/Commands/CurlCommand.php
+++ b/app/Console/Commands/CurlCommand.php
@@ -23,6 +23,7 @@ class CurlCommand extends Command
             'timeout' => $this->option('connect-timeout'),
             'retry' => $this->option('retry'),
             'silent' => $this->option('silent'),
+            'user' => $this->option('user'),
             // TODO: map more options...
         ];
 


### PR DESCRIPTION
Just added a few more common option types that can be easily mapped to equivalent methods of Laravel's Http class.  I'm sure more can be done with some digging but these were the ones that I see used most often on API doc pages and would be good candidates to automatically convert.