### PR TITLE
Parse query string into data array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 /.idea
 /.vscode
 composer.lock
+docker-compose.yml

--- a/app/Models/Request.php
+++ b/app/Models/Request.php
@@ -30,7 +30,13 @@ class Request
 
     public static function create(array $data): self
     {
-        $request = new self($data['url'], $data['method']);
+        $url = parse_url($data['url']);
+
+        $request = new self(self::buildUrl($url), $data['method']);
+
+        if (isset($url['query'])) {
+            parse_str($url['query'], $request->data);
+        }
 
         if (!empty($data['headers'])) {
             $request->headers = collect($data['headers'])
@@ -123,5 +129,20 @@ class Request
         });
 
         return $data;
+    }
+
+    private static function buildUrl(array $url): string
+    {
+        $output = $url['scheme'] . '://' . $url['host'];
+
+        if (isset($url['port'])) {
+            $output .= ':' . $url['port'];
+        }
+
+        if (isset($url['path'])) {
+            $output .= $url['path'];
+        }
+
+        return $output;
     }
 }

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -29,6 +29,7 @@ class CurlCommandTest extends TestCase
             'POST request with JSON data' => ['post-json'],
             'POST request with multipart/form-data' => ['post-with-form-data'],
             'GET request with headers' => ['with-headers'],
+            'GET request with query string' => ['with-query-string'],
             'Mailgun example request' => ['mailgun-example'],
             'Digital Ocean example request' => ['digital-ocean-example'],
             'Stripe example request' => ['stripe-example'],

--- a/tests/fixtures/get-with-query-string.in
+++ b/tests/fixtures/get-with-query-string.in
@@ -1,0 +1,1 @@
+curl "https://api.postmarkapp.com/messages/outbound?recipient=john.doe@yahoo.com&count=50&offset=0&tag=welcome&status=sent&todate=2015-01-12&fromdate=2015-01-01" -X GET

--- a/tests/fixtures/get-with-query-string.in
+++ b/tests/fixtures/get-with-query-string.in
@@ -1,1 +1,0 @@
-curl "https://api.postmarkapp.com/messages/outbound?recipient=john.doe@yahoo.com&count=50&offset=0&tag=welcome&status=sent&todate=2015-01-12&fromdate=2015-01-01" -X GET

--- a/tests/fixtures/with-query-string.in
+++ b/tests/fixtures/with-query-string.in
@@ -1,0 +1,1 @@
+curl "https://api.postmarkapp.com/messages/outbound?recipient=john.doe@yahoo.com&count=50&offset=0&tag=welcome&status=sent&todate=2015-01-12&fromdate=2015-01-01" -X GET

--- a/tests/fixtures/with-query-string.out
+++ b/tests/fixtures/with-query-string.out
@@ -1,0 +1,9 @@
+Http::get('https://api.postmarkapp.com/messages/outbound', [
+        'recipient' => 'john.doe@yahoo.com',
+        'count' => '50',
+        'offset' => '0',
+        'tag' => 'welcome',
+        'status' => 'sent',
+        'todate' => '2015-01-12',
+        'fromdate' => '2015-01-01',
+    ]);


### PR DESCRIPTION
This PR extracts the URL query string to the data array in the Laravel HTTP client.

For example, 

`curl "https://api.postmarkapp.com/messages/outbound?recipient=john.doe@yahoo.com&count=50&offset=0&tag=welcome&status=sent&todate=2015-01-12&fromdate=2015-01-01" -X GET`

currently yields this HTTP request:

```php
Http::get('https://api.postmarkapp.com/messages/outbound?recipient=john.doe@yahoo.com&count=50&offset=0&tag=welcome&status=sent&todate=2015-01-12&fromdate=2015-01-01');
```

Which technically works but it not very readable. Now it will instead output this:

```php
Http::get('https://api.postmarkapp.com/messages/outbound', [
        'recipient' => 'john.doe@yahoo.com',
        'count' => '50',
        'offset' => '0',
        'tag' => 'welcome',
        'status' => 'sent',
        'todate' => '2015-01-12',
        'fromdate' => '2015-01-01',
    ]);
```

Which makes query string parameters much more readable and easy to edit the individual values in the code.

**NOTE**: This uses PHP's [parse_url](https://www.php.net/manual/en/function.parse-url.php). This creates a refactoring opportunity in `App/Models/Request` on line 65 to use it to get the Http Basic Auth username and password instead of exploding the raw URL string.