### PR TITLE
Adding connectTimeout() and timeout() options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ yarn-error.log
 /.vscode
 composer.lock
 docker-compose.yml
+/storage/logs
+/bootstrap/cache

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ yarn-error.log
 /.vscode
 composer.lock
 docker-compose.yml
-/storage/logs
-/bootstrap/cache

--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -7,7 +7,7 @@ use Shift\CurlConverter\Support\HttpCall;
 
 class CurlCommand extends Command
 {
-    protected $signature = 'shift:curl {--X|request=GET} {--H|header=*} {--d|data=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--retry=} {--s|silent} {--u|user=} {url}';
+    protected $signature = 'shift:curl {--X|request=GET} {--H|header=*} {--d|data=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {url}';
 
     protected $description = 'Convert a UNIX curl request to an HTTP Client request';
 
@@ -31,7 +31,8 @@ class CurlCommand extends Command
             'fields' => $this->option('form'),
             'digest' => $this->option('digest'),
             'basic' => $this->option('basic'),
-            'timeout' => $this->option('connect-timeout'),
+            'connectTimeout' => $this->option('connect-timeout'),
+            'maxTimeout' => $this->option('max-timeout'),
             'retry' => $this->option('retry'),
             'silent' => $this->option('silent'),
             'user' => $this->option('user'),

--- a/src/Models/Request.php
+++ b/src/Models/Request.php
@@ -22,6 +22,10 @@ class Request
 
     private ?string $password = null;
 
+    private ?int $maxTimeout = null;
+
+    private ?int $connectTimeout = null;
+
     private function __construct($url, $method)
     {
         $this->url = $url;
@@ -70,6 +74,14 @@ class Request
             [$request->username, $request->password] = explode(':', $data['user'], 2);
         }
 
+        if ($data['maxTimeout']) {
+            $request->maxTimeout = $data['maxTimeout'];
+        }
+
+        if ($data['connectTimeout']) {
+            $request->connectTimeout = $data['connectTimeout'];
+        }
+
         return $request;
     }
 
@@ -81,6 +93,16 @@ class Request
     public function hasUsernameOrPassword(): bool
     {
         return isset($this->username) || isset($this->password);
+    }
+
+    public function hasMaxTimeout(): bool
+    {
+        return isset($this->maxTimeout);
+    }
+
+    public function hasConnectTimeout(): bool
+    {
+        return isset($this->connectTimeout);
     }
 
     public function headers(): array
@@ -116,6 +138,16 @@ class Request
     public function password(): string
     {
         return $this->password ?? '';
+    }
+
+    public function maxTimeout(): int
+    {
+        return $this->maxTimeout;
+    }
+
+    public function connectTimeout(): int
+    {
+        return $this->connectTimeout;
     }
 
     private static function convertDataType(string $value)

--- a/src/Support/HttpCall.php
+++ b/src/Support/HttpCall.php
@@ -85,11 +85,11 @@ class HttpCall
             $options[] = 'withHeaders(' . self::prettyPrintArray($headers) . ')';
         }
 
-        if (!empty($request->hasMaxTimeout())) {
+        if ($request->hasMaxTimeout()) {
             $options[] = 'timeout(' . $request->maxTimeout() . ')';
         }
 
-        if (!empty($request->hasConnectTimeout())) {
+        if ($request->hasConnectTimeout()) {
             $options[] = 'connectTimeout(' . $request->connectTimeout() . ')';
         }
 

--- a/src/Support/HttpCall.php
+++ b/src/Support/HttpCall.php
@@ -85,6 +85,14 @@ class HttpCall
             $options[] = 'withHeaders(' . self::prettyPrintArray($headers) . ')';
         }
 
+        if (!empty($request->hasMaxTimeout())) {
+            $options[] = 'timeout(' . $request->maxTimeout() . ')';
+        }
+
+        if (!empty($request->hasConnectTimeout())) {
+            $options[] = 'connectTimeout(' . $request->connectTimeout() . ')';
+        }
+
         if (empty($options)) {
             return '';
         }

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -37,6 +37,8 @@ class CurlCommandTest extends TestCase
             'Mailgun example request' => ['mailgun-example'],
             'Digital Ocean example request' => ['digital-ocean-example'],
             'Stripe example request' => ['stripe-example'],
+            'Initial connection timeout' => ['connect-timeout'],
+            'Entire transaction timeout' => ['max-timeout'],
         ];
     }
 }

--- a/tests/fixtures/connect-timeout.in
+++ b/tests/fixtures/connect-timeout.in
@@ -1,0 +1,1 @@
+curl --connect-timeout 5 https://example.com

--- a/tests/fixtures/connect-timeout.out
+++ b/tests/fixtures/connect-timeout.out
@@ -1,0 +1,2 @@
+Http::connectTimeout(5)
+    ->get('https://example.com');

--- a/tests/fixtures/max-timeout.in
+++ b/tests/fixtures/max-timeout.in
@@ -1,0 +1,1 @@
+curl --max-timeout 5 https://example.com

--- a/tests/fixtures/max-timeout.out
+++ b/tests/fixtures/max-timeout.out
@@ -1,0 +1,2 @@
+Http::timeout(5)
+    ->get('https://example.com');


### PR DESCRIPTION
This PR adds support for the `connectTimeout()` (setting up the initial HTTP connection) and `timeout()` (the entire transaction) options.