### PR TITLE
Ignore cURL's `--location` flag

### DIFF
--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -7,7 +7,7 @@ use Shift\CurlConverter\Support\HttpCall;
 
 class CurlCommand extends Command
 {
-    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {url}';
+    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {url}';
 
     protected $description = 'Convert a UNIX curl request to an HTTP Client request';
 

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -20,6 +20,18 @@ class CurlCommandTest extends TestCase
         $this->assertSame($this->fixture($fixture . '.out'), $output);
     }
 
+    /**
+     * @test
+     *
+     * The "--location" flag tells cURL to follow any redirects.
+     * This is the default behaviour for Laravel's Http client so it can be safely ignored.
+     */
+    public function the_location_curl_flag_can_be_ignored()
+    {
+        $this->artisan('shift:curl --location http://laravel.com')->assertSuccessful();
+        $this->artisan('shift:curl -L http://laravel.com')->assertSuccessful();
+    }
+
     public function curlCommandFixtures()
     {
         return [

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -20,18 +20,6 @@ class CurlCommandTest extends TestCase
         $this->assertSame($this->fixture($fixture . '.out'), $output);
     }
 
-    /**
-     * @test
-     *
-     * The "--location" flag tells cURL to follow any redirects.
-     * This is the default behaviour for Laravel's Http client so it can be safely ignored.
-     */
-    public function the_location_curl_flag_can_be_ignored()
-    {
-        $this->artisan('shift:curl --location http://laravel.com')->assertSuccessful();
-        $this->artisan('shift:curl -L http://laravel.com')->assertSuccessful();
-    }
-
     public function curlCommandFixtures()
     {
         return [
@@ -52,6 +40,7 @@ class CurlCommandTest extends TestCase
             'Stripe query params' => ['stripe-query-params'],
             'Initial connection timeout' => ['connect-timeout'],
             'Entire transaction timeout' => ['max-timeout'],
+            'Ignore location flag' => ['ignore-location-flag'],
         ];
     }
 

--- a/tests/fixtures/ignore-location-flag.in
+++ b/tests/fixtures/ignore-location-flag.in
@@ -1,0 +1,1 @@
+curl --location -L https://example.com

--- a/tests/fixtures/ignore-location-flag.in
+++ b/tests/fixtures/ignore-location-flag.in
@@ -1,1 +1,1 @@
-curl --location -L https://example.com
+curl --location https://example.com

--- a/tests/fixtures/ignore-location-flag.out
+++ b/tests/fixtures/ignore-location-flag.out
@@ -1,0 +1,1 @@
+Http::get('https://example.com');


### PR DESCRIPTION
Closes #10 

When the `--location` or `-L` shortcut is given to follow redirects, it is silently dropped since this is the default `Http` client behaviour.