### PR TITLE
Accept data-raw 

### DIFF
--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -7,12 +7,13 @@ use Shift\CurlConverter\Support\HttpCall;
 
 class CurlCommand extends Command
 {
-    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {url}';
+    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {--compressed} {--insecure} {url}';
 
     protected $description = 'Convert a UNIX curl request to an HTTP Client request';
 
     public function handle()
     {
+        // dd($this->gatherOptions());
         $request = \Shift\CurlConverter\Models\Request::create($this->gatherOptions());
         $code = HttpCall::format($request);
 
@@ -39,6 +40,8 @@ class CurlCommand extends Command
             'retry' => $this->option('retry'),
             'silent' => $this->option('silent'),
             'user' => $this->option('user'),
+            'compressed' => $this->option('compressed'),
+            'insecure' => $this->option('insecure')
         ];
     }
 }

--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -13,7 +13,6 @@ class CurlCommand extends Command
 
     public function handle()
     {
-        // dd($this->gatherOptions());
         $request = \Shift\CurlConverter\Models\Request::create($this->gatherOptions());
         $code = HttpCall::format($request);
 

--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -40,7 +40,7 @@ class CurlCommand extends Command
             'silent' => $this->option('silent'),
             'user' => $this->option('user'),
             'compressed' => $this->option('compressed'),
-            'insecure' => $this->option('insecure')
+            'insecure' => $this->option('insecure'),
         ];
     }
 }

--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -7,7 +7,7 @@ use Shift\CurlConverter\Support\HttpCall;
 
 class CurlCommand extends Command
 {
-    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {--compressed} {--insecure} {url}';
+    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-raw=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {--compressed} {--insecure} {url}';
 
     protected $description = 'Convert a UNIX curl request to an HTTP Client request';
 
@@ -29,7 +29,7 @@ class CurlCommand extends Command
             'method' => $this->option('get') ? 'GET' : $this->option('request'),
             'url' => $this->argument('url'),
             'headers' => $this->option('header'),
-            'data' => $this->option('data'),
+            'data' => count($this->option('data-raw')) > 0 ? $this->option('data-raw') : $this->option('data'),
             'dataUrlEncode' => $this->option('data-urlencode'),
             'fields' => $this->option('form'),
             'digest' => $this->option('digest'),

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -43,8 +43,8 @@ class CurlCommandTest extends TestCase
             'Entire transaction timeout' => ['max-timeout'],
             'Ignore location flag' => ['ignore-location-flag'],
             'Missing URL scheme' => ['missing-url-scheme'],
-            'GET request with compressed flag' => ['with-compressed-option'],
-            'GET request with compressed flag' => ['with-insecure-option'],
+            'GET request with compressed option' => ['with-compressed-option'],
+            'GET request with insecure option' => ['with-insecure-option'],
         ];
     }
 

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -44,7 +44,7 @@ class CurlCommandTest extends TestCase
             'Ignore location flag' => ['ignore-location-flag'],
             'Missing URL scheme' => ['missing-url-scheme'],
             'GET request with compressed flag' => ['with-compressed-option'],
-            'GET request with compressed flag' => ['with-insecure-option']
+            'GET request with compressed flag' => ['with-insecure-option'],
         ];
     }
 

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -27,6 +27,7 @@ class CurlCommandTest extends TestCase
             'POST request' => ['basic-post'],
             'POST request with data' => ['post-with-data'],
             'POST request with JSON data' => ['post-json'],
+            'POST request with JSON data-raw' => ['post-json-data-raw'],
             'POST request with multipart/form-data' => ['post-with-form-data'],
             'Request with data defaults to POST' => ['request-with-data'],
             'Request with form fields defaults to POST' => ['request-with-form-data'],

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -42,6 +42,8 @@ class CurlCommandTest extends TestCase
             'Entire transaction timeout' => ['max-timeout'],
             'Ignore location flag' => ['ignore-location-flag'],
             'Missing URL scheme' => ['missing-url-scheme'],
+            'GET request with compressed flag' => ['with-compressed-option'],
+            'GET request with compressed flag' => ['with-insecure-option']
         ];
     }
 

--- a/tests/fixtures/post-json-data-raw.in
+++ b/tests/fixtures/post-json-data-raw.in
@@ -1,0 +1,1 @@
+curl -X POST --header 'Content-Type: application/json' --data-raw '{"messages": ["a","b","c"]}' 'https://api.com'

--- a/tests/fixtures/post-json-data-raw.out
+++ b/tests/fixtures/post-json-data-raw.out
@@ -1,0 +1,2 @@
+Http::withBody('{"messages": ["a","b","c"]}')
+    ->post('https://api.com');

--- a/tests/fixtures/with-compressed-option.in
+++ b/tests/fixtures/with-compressed-option.in
@@ -1,0 +1,1 @@
+curl -H 'Accept: application/json' https://example.com --compressed

--- a/tests/fixtures/with-compressed-option.out
+++ b/tests/fixtures/with-compressed-option.out
@@ -1,0 +1,2 @@
+Http::acceptJson()
+    ->get('https://example.com');

--- a/tests/fixtures/with-insecure-option.in
+++ b/tests/fixtures/with-insecure-option.in
@@ -1,0 +1,1 @@
+curl -H 'Accept: application/json' https://example.com --insecure

--- a/tests/fixtures/with-insecure-option.out
+++ b/tests/fixtures/with-insecure-option.out
@@ -1,0 +1,2 @@
+Http::acceptJson()
+    ->get('https://example.com');


### PR DESCRIPTION
Added support for providing `data-raw` according to #8. 

My reasoning for the proposed solution is that they should never be present simultaneously, and if `data-raw` isn't present, then go for default behavior with the `-d|data`-option, giving `data-raw` a slight precedence over `data`.