### PR TITLE
Support `--data-raw`

### DIFF
--- a/src/Console/Commands/CurlCommand.php
+++ b/src/Console/Commands/CurlCommand.php
@@ -7,7 +7,7 @@ use Shift\CurlConverter\Support\HttpCall;
 
 class CurlCommand extends Command
 {
-    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {--compressed} {--insecure} {url}';
+    protected $signature = 'shift:curl {--X|request=} {--G|get} {--H|header=*} {--d|data=*} {--data-urlencode=*} {--data-raw=*} {--F|form=*} {--digest} {--basic} {--connect-timeout=} {--max-timeout=} {--retry=} {--s|silent} {--u|user=} {--L|location} {--compressed} {--insecure} {url}';
 
     protected $description = 'Convert a UNIX curl request to an HTTP Client request';
 
@@ -30,6 +30,7 @@ class CurlCommand extends Command
             'url' => $this->argument('url'),
             'headers' => $this->option('header'),
             'data' => $this->option('data'),
+            'rawData' => $this->option('data-raw'),
             'dataUrlEncode' => $this->option('data-urlencode'),
             'fields' => $this->option('form'),
             'digest' => $this->option('digest'),

--- a/src/Models/Request.php
+++ b/src/Models/Request.php
@@ -79,7 +79,7 @@ class Request
             $request->multipartFormData = true;
         }
 
-        if (is_null($data['method']) && (!empty($data['rawData']) || !empty($data['data']) || !empty($data['fields'] ))) {
+        if (is_null($data['method']) && (!empty($data['rawData']) || !empty($data['data']) || !empty($data['fields']))) {
             $request->method = 'POST';
         }
 

--- a/src/Support/HttpCall.php
+++ b/src/Support/HttpCall.php
@@ -67,8 +67,8 @@ class HttpCall
         if (!empty($request->data()) && $request->method() !== 'GET') {
             if ($request->isMultipartFormData()) {
                 $options[] = 'asMultipart()';
-            } elseif ($request->isJsonData()) {
-                $options[] = 'withBody(\'' . $request->data()[0] . '\')';
+            } elseif ($request->isRawData()) {
+                $options[] = 'withBody(\'' . current($request->data()) . '\')';
             } else {
                 $options[] = 'asForm()';
             }
@@ -102,7 +102,7 @@ class HttpCall
 
     private static function generateRequest(Request $request): string
     {
-        if (empty($request->data()) || $request->isJsonData()) {
+        if (empty($request->data()) || $request->isRawData()) {
             return "'" . $request->url() . "'";
         }
 

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -44,6 +44,8 @@ class CurlCommandTest extends TestCase
             'Missing URL scheme' => ['missing-url-scheme'],
             'GET request with compressed flag' => ['with-compressed-option'],
             'GET request with insecure flag' => ['with-insecure-option'],
+            'Request with raw data' => ['with-raw-data'],
+            'POST request with mixed data' => ['raw-data-mixed'],
         ];
     }
 

--- a/tests/fixtures/raw-data-mixed.in
+++ b/tests/fixtures/raw-data-mixed.in
@@ -1,0 +1,1 @@
+curl --request POST 'https://api.com' --header 'Accept: application/json' --data-raw 'some=data' -d foo=bar

--- a/tests/fixtures/raw-data-mixed.out
+++ b/tests/fixtures/raw-data-mixed.out
@@ -1,0 +1,6 @@
+Http::asForm()
+    ->acceptJson()
+    ->post('https://api.com', [
+        'some' => 'data',
+        'foo' => 'bar',
+    ]);

--- a/tests/fixtures/with-raw-data.in
+++ b/tests/fixtures/with-raw-data.in
@@ -1,0 +1,7 @@
+curl 'https://api.com' --header 'Accept: application/json' --header 'Content-Type: application/json' --data-raw '{
+    "messages": [
+        "a",
+        "b",
+        "c"
+    ]
+}'

--- a/tests/fixtures/with-raw-data.out
+++ b/tests/fixtures/with-raw-data.out
@@ -1,0 +1,9 @@
+Http::withBody('{
+    "messages": [
+        "a",
+        "b",
+        "c"
+    ]
+}')
+    ->acceptJson()
+    ->post('https://api.com');


### PR DESCRIPTION
The `--data-raw` option takes some interpretation. The `curl` docs do not state that it is mutually exclusive from `--data`. From a quick tests, it seems `curl` merges the data when called with both `--data` and `--data-raw`.

With that said, the common use case for `--data-raw` seems to be independent. When passed alone, this is the exact data to send in the request _payload_.

This PR adds support for `--data-raw` to the specification above - parsing it as form data when mixed with `--data` or sending it as the raw body when used independently.