### PR TITLE
throw exception for invalid headers

### DIFF
--- a/src/Models/Request.php
+++ b/src/Models/Request.php
@@ -52,9 +52,10 @@ class Request
                 ->mapWithKeys(function ($header) {
                     if (!str_contains($header, ':')) {
                         throw new InvalidArgumentException(
-                            sprintf('The "%s" header  must be key/value pair separated by ":".', $header)
+                            sprintf('The "%s" header must be key/value pair separated by ":".', $header)
                         );
                     }
+
                     [$key, $value] = explode(':', $header, 2);
 
                     return [trim($key) => self::convertDataType(trim($value))];

--- a/src/Models/Request.php
+++ b/src/Models/Request.php
@@ -50,6 +50,11 @@ class Request
         if (!empty($data['headers'])) {
             $request->headers = collect($data['headers'])
                 ->mapWithKeys(function ($header) {
+                    if (!str_contains($header, ':')) {
+                        throw new InvalidArgumentException(
+                            sprintf('The "%s" header  must be key/value pair separated by ":".', $header)
+                        );
+                    }
                     [$key, $value] = explode(':', $header, 2);
 
                     return [trim($key) => self::convertDataType(trim($value))];

--- a/src/Models/Request.php
+++ b/src/Models/Request.php
@@ -52,7 +52,7 @@ class Request
                 ->mapWithKeys(function ($header) {
                     if (!str_contains($header, ':')) {
                         throw new InvalidArgumentException(
-                            sprintf('The "%s" header must be key/value pair separated by ":".', $header)
+                            sprintf('The "%s" header must be a key/value pair separated by ":".', $header)
                         );
                     }
 

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -29,6 +29,14 @@ class CurlCommandTest extends TestCase
         Artisan::call('shift:curl -X GET "https://{domain:port}/api/{id}/"');
     }
 
+    public function test_it_throw_exception_when_for_invalid_headers()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "foo" header  must be key/value pair separated by ":".');
+
+        Artisan::call("shift:curl https://example.com --header 'foo'");
+    }
+
     public function curlCommandFixtures()
     {
         return [

--- a/tests/Feature/Console/Commands/CurlCommandTest.php
+++ b/tests/Feature/Console/Commands/CurlCommandTest.php
@@ -32,7 +32,7 @@ class CurlCommandTest extends TestCase
     public function test_it_throw_exception_when_for_invalid_headers()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "foo" header  must be key/value pair separated by ":".');
+        $this->expectExceptionMessage('The "foo" header must be a key/value pair separated by ":".');
 
         Artisan::call("shift:curl https://example.com --header 'foo'");
     }


### PR DESCRIPTION
closes #19 
Fix crash when header is not a key/value pair separated by a ":" by throwing `InvalidArgumentException`